### PR TITLE
Fix weather temp format in waybar script

### DIFF
--- a/waybar/scripts/waybar-wttr.py
+++ b/waybar/scripts/waybar-wttr.py
@@ -66,7 +66,7 @@ def format_time(time):
 
 
 def format_temp(temp):
-    return (hour['FeelsLikeC']+"°").ljust(3)
+    return (temp+"°").ljust(3)
 
 
 def format_chances(hour):


### PR DESCRIPTION
## Summary
- fix `waybar-wttr.py` to format temperature parameter correctly

## Testing
- `python3 -m py_compile waybar/scripts/waybar-wttr.py`

------
https://chatgpt.com/codex/tasks/task_e_68403f17503c8321807f09fe787ef676